### PR TITLE
Fix invalid rgba syntax

### DIFF
--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -174,7 +174,7 @@ section {
       background-image: url('../static/savethedate.png');
       background-position: center;
       background-repeat: no-repeat;
-      background-color: rgba(#000, 0.3);
+      background-color: rgba(0, 0, 0, 0.3);
       background-size: $savethedate;
       text-indent: -9999px;
     }


### PR DESCRIPTION
## Summary
- fix Sass color syntax for `rgba(0,0,0,0.3)`

## Testing
- `npm run lint:styles` *(fails: stylelint not found)*
- `npm run lint:js` *(fails: eslint not found)*
- `npm run build` *(fails: webpack not found)*


------
https://chatgpt.com/codex/tasks/task_e_684589bf8684832083d4c698656de0ee